### PR TITLE
Corrects conversion to spoiler annotation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bbcode-to-markdown",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "bbcode-to-markdown ==================",
   "main": "./src/bbcode-to-markdown.js",
   "scripts": {

--- a/src/newToMarkdownOptions.js
+++ b/src/newToMarkdownOptions.js
@@ -16,7 +16,7 @@ var options = extend(true, {
 		{
 			filter: 'spoiler',
 			replacement: function (innerHTML) {
-				return '\n>! ' + (innerHTML || '').split('\n').join('\n>! ');
+				return '\n>! ' + (innerHTML || '').split(/\n[\n]+/).join('\n\n>! ');
 			}
 		},
 		{


### PR DESCRIPTION
I noticed that when a `[spoiler]` tag was converted to nbb md for a spoiler you would end up with an output like this:

```
>! Here's the first line
>! and a newline
>!
>! and a line after a space
```

This fixes it to output:

```
>! Here's the first line
and a newline

>! and a line after a space
```
